### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "express": "^4.17.1",
     "extract-zip": "^2.0.1",
     "gtfs-realtime-bindings": "^1.0.0",
-    "node-fetch": "^2.7.0"
+    "node-fetch": "^2.7.0",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -116,6 +116,7 @@ function extractBusNumber(vehicleId) {
 dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
 const app = express();
+const RateLimit = require('express-rate-limit');
 const PORT = process.env.PORT || 3000;
 const API_KEY = process.env.API_KEY;
 
@@ -133,7 +134,11 @@ if (API_KEY) {
 app.use(express.static('/app/frontend'));
 
 // Route till admin-sidan för att se status för GTFS-data
-app.get('/status', (req, res) => {
+const statusLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+app.get('/status', statusLimiter, (req, res) => {
   res.sendFile('/app/frontend/gtfs-status.html');
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/acidflash/xtrafik/security/code-scanning/1](https://github.com/acidflash/xtrafik/security/code-scanning/1)

To address the issue, we will introduce rate limiting to the application using the `express-rate-limit` middleware. This middleware will limit the number of requests a client can make within a specified time window. Specifically, we will:

1. Install and configure the `express-rate-limit` package.
2. Apply the rate limiter globally to all routes or specifically to the `/status` route, depending on the desired scope.
3. Ensure the rate limiter is configured with reasonable defaults, such as allowing 100 requests per 15 minutes.

This fix will prevent abuse of the `/status` route and other routes if applied globally, mitigating the risk of DoS attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
