### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -143,7 +143,12 @@ app.get('/status', statusLimiter, (req, res) => {
 });
 
 // Diagnostik-endpoint för att kontrollera status för GTFS-data
-app.get('/api/gtfs-status', (req, res) => {
+const gtfsStatusLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+app.get('/api/gtfs-status', gtfsStatusLimiter, (req, res) => {
   try {
     const routeMap = gtfsLoader.getRouteMap();
     const tripMap = gtfsLoader.getTripMap();


### PR DESCRIPTION
Potential fix for [https://github.com/acidflash/xtrafik/security/code-scanning/2](https://github.com/acidflash/xtrafik/security/code-scanning/2)

To address the issue, we will add rate limiting to the `/api/gtfs-status` route using the `express-rate-limit` package, which is already imported in the file. This will ensure that the number of requests to this endpoint is controlled, reducing the risk of DoS attacks. Specifically, we will define a rate limiter for this route, similar to the one used for `/status`, and apply it to the `/api/gtfs-status` route handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
