### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -220,7 +220,12 @@ app.get('/admin/refresh-gtfs', statusLimiter, async (req, res) => {
 });
 
 // "Catch-all" rutt för att hantera SPA-routing (om tillämpligt)
-app.get('*', (req, res) => {
+const catchAllLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // max 50 requests per windowMs
+});
+
+app.get('*', catchAllLimiter, (req, res) => {
   // Kontrollera om begäran är för en API-endpoint
   if (req.path.startsWith('/api/')) {
     return res.status(404).json({ error: 'API endpoint hittades inte' });


### PR DESCRIPTION
Potential fix for [https://github.com/acidflash/xtrafik/security/code-scanning/3](https://github.com/acidflash/xtrafik/security/code-scanning/3)

To address the issue, we will add rate limiting to the "catch-all" route handler on line 223. We will use the `express-rate-limit` package, which is already imported in the file. A new rate limiter will be defined specifically for this route, with a reasonable limit on the number of requests per time window. This ensures that the file system access is not overwhelmed by excessive requests.

Steps:
1. Define a new rate limiter (e.g., `catchAllLimiter`) with appropriate settings.
2. Apply the rate limiter to the "catch-all" route handler by adding it as middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
